### PR TITLE
Add working directory to path to resolve binary

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.0.8</Version>
+        <Version>0.0.9</Version>
         <Authors>Tony Redondo</Authors>
         <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TimeIt/ScenarioProcessor.cs
+++ b/src/TimeIt/ScenarioProcessor.cs
@@ -330,6 +330,10 @@ public class ScenarioProcessor
             cmdEnvironmentVariables[Constants.TimeItMetricsTemporalPathEnvironmentVariable] = Path.GetTempFileName();
         }
 
+        // add working directory as a path to resolve binary
+        var pathWithWorkingDir = workingDirectory + Path.PathSeparator + Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", pathWithWorkingDir);
+
         // Setup the command
         var cmd = Cli.Wrap(cmdString)
             .WithEnvironmentVariables(cmdEnvironmentVariables)
@@ -437,7 +441,7 @@ public class ScenarioProcessor
                                 {
                                     metrics[Constants.ProcessInternalDurationMetricName] = (inProcEndDate.Value - inProcStartDate.Value).TotalMilliseconds;
                                 }
-                                
+
                                 continue;
                             }
 

--- a/src/TimeIt/TimeIt.csproj
+++ b/src/TimeIt/TimeIt.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CliWrap" Version="3.5.0" />
+        <PackageReference Include="CliWrap" Version="3.6.4" />
         <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
         <PackageReference Include="Spectre.Console" Version="0.45.0" />
     </ItemGroup>


### PR DESCRIPTION
As of today, when we have this configuration
```
  "processName": "Foo.exe",
  "processArguments": "Samples.Computer01.dll --scenario 5 --iterations 1",
  "processTimeout": 15,
  "workingDirectory": "$(CWD)\\..\\My\\Super\\Path",
```

`Foo.exe` wont' be look for in the working directory. If we want it to work, we have to do 
```
  "processName": "$(CWD)\\..\\My\\Super\\Path\\Foo.exe",
  "processArguments": "Samples.Computer01.dll --scenario 5 --iterations 1",
  "processTimeout": 15,
  "workingDirectory": "$(CWD)\\..\\My\\Super\\Path",
```
Which works but involve copy/pasted and is error-prone.

By adding the working directory to the `PATH` env var, the `Command` object will be able to resolve the binary in the working directory.
