### PR TITLE
Add template variables support

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.0.12</Version>
+        <Version>0.0.13</Version>
         <Authors>Tony Redondo</Authors>
         <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TimeIt/Program.cs
+++ b/src/TimeIt/Program.cs
@@ -4,93 +4,133 @@ using TimeIt.Common.Configuration;
 using TimeIt.Common.Exporter;
 using TimeIt.Common.Results;
 using TimeIt.DatadogExporter;
+using System.CommandLine;
 
 AnsiConsole.MarkupLine("[bold dodgerblue1 underline]TimeIt (v. {0}) by Tony Redondo[/]\n", typeof(Utils).Assembly.GetName().Version?.ToString() ?? "unknown");
 
-// Check arguments
-if (args.Length < 1)
-{
-    AnsiConsole.MarkupLine("[red]Missing argument with the configuration file.[/]");
-    Environment.Exit(1);
-    return;
-}
-
-// Load configuration
-var config = Config.LoadConfiguration(args[0]);
-config.JsonExporterFilePath = Utils.ReplaceCustomVars(config.JsonExporterFilePath);
-
-// Create scenario processor
-var processor = new ScenarioProcessor(config);
-
-// Enable exporters
-var exporters = new List<IExporter>();
-exporters.Add(new ConsoleExporter());
-exporters.Add(new JsonExporter());
-exporters.Add(new TimeItDatadogExporter());
-
-AnsiConsole.MarkupLine("[bold aqua]Warmup count:[/] {0}", config.WarmUpCount);
-AnsiConsole.MarkupLine("[bold aqua]Count:[/] {0}", config.Count);
-AnsiConsole.MarkupLine("[bold aqua]Number of Scenarios:[/] {0}", config.Scenarios.Count);
-AnsiConsole.MarkupLine("[bold aqua]Exporters:[/] {0}", string.Join(", ", exporters.Select(e => e.Name)));
-AnsiConsole.WriteLine();
-
-// Process scenarios
-var scenariosResults = new List<ScenarioResult>();
-var scenarioWithErrors = 0;
-if (config is { Count: > 0, Scenarios.Count: > 0 })
-{
-    foreach (var scenario in config.Scenarios)
+var argument = new Argument<string>("configuration file", "The JSON configuration file");
+var templateVariables = new Option<TemplateVariables>("--variable", isDefault: true, description: "Variables used to instantiate the configuration file",
+    parseArgument: result =>
     {
-        // Prepare scenario
-        processor.PrepareScenario(scenario);
-        
-        // Process scenario
-        var result = await processor.ProcessScenarioAsync(scenario).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(result.Error))
+        var tvs = new TemplateVariables();
+
+        foreach (var token in result.Tokens)
         {
-            scenarioWithErrors++;
+            var variableValue = token.Value; ;
+            var idx = variableValue.IndexOf('=');
+            if (idx == -1)
+            {
+                AnsiConsole.MarkupLine("[bold red]Unknown format: variable must be of the form[/][bold blue] key=value[/]");
+                continue;
+            }
+
+            if (idx == variableValue.Length - 1)
+            {
+                AnsiConsole.MarkupLine("[bold red]No variable value provided. Skipped.[/]");
+                continue;
+            }
+
+            if (idx == 0)
+            {
+                AnsiConsole.MarkupLine("[bold red]No variable name provided. Skipped.[/]");
+                continue;
+            }
+
+            var keyVal = variableValue.Split('=');
+            tvs.Add(keyVal[0], keyVal[1]);
         }
+        return tvs;
 
-        scenariosResults.Add(result);
-    }
+    }) { Arity = ArgumentArity.OneOrMore };
 
-    if (scenarioWithErrors < config.Scenarios.Count)
+var root = new RootCommand
+{
+    argument,
+    templateVariables
+};
+
+root.SetHandler(async (configFile, templateVariables) =>
+{
+    // Load configuration
+    var config = Config.LoadConfiguration(configFile);
+    config.JsonExporterFilePath = templateVariables.Expand(config.JsonExporterFilePath);
+
+    // Create scenario processor
+    var processor = new ScenarioProcessor(config, templateVariables);
+
+    // Enable exporters
+    var exporters = new List<IExporter>();
+    exporters.Add(new ConsoleExporter());
+    exporters.Add(new JsonExporter());
+    exporters.Add(new TimeItDatadogExporter());
+
+    AnsiConsole.MarkupLine("[bold aqua]Warmup count:[/] {0}", config.WarmUpCount);
+    AnsiConsole.MarkupLine("[bold aqua]Count:[/] {0}", config.Count);
+    AnsiConsole.MarkupLine("[bold aqua]Number of Scenarios:[/] {0}", config.Scenarios.Count);
+    AnsiConsole.MarkupLine("[bold aqua]Exporters:[/] {0}", string.Join(", ", exporters.Select(e => e.Name)));
+    AnsiConsole.WriteLine();
+
+    // Process scenarios
+    var scenariosResults = new List<ScenarioResult>();
+    var scenarioWithErrors = 0;
+    if (config is { Count: > 0, Scenarios.Count: > 0 })
     {
-	    // Export data
-	    foreach (var exporter in exporters)
-	    {
-		    exporter.SetConfiguration(config);
-		    if (exporter.Enabled)
-		    {
-			    exporter.Export(scenariosResults);
-		    }
-	    }
-
-        // Clean scenarios
         foreach (var scenario in config.Scenarios)
         {
-	        processor.CleanScenario(scenario);
+            // Prepare scenario
+            processor.PrepareScenario(scenario);
+
+            // Process scenario
+            var result = await processor.ProcessScenarioAsync(scenario).ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(result.Error))
+            {
+                scenarioWithErrors++;
+            }
+
+            scenariosResults.Add(result);
         }
-    }
-    else
-    {
-	    AnsiConsole.WriteLine();
 
-	    for (var i = 0; i < scenariosResults.Count; i++)
-	    {
-		    if (!string.IsNullOrEmpty(scenariosResults[i].Error))
-		    {
-			    AnsiConsole.MarkupLine("[red]Error in Scenario[/]: {0}", scenariosResults[i].Name);
-			    AnsiConsole.WriteLine(scenariosResults[i].Error);
-		    }
-	    }
-
-        // Clean scenarios
-        foreach (var scenario in config.Scenarios)
+        if (scenarioWithErrors < config.Scenarios.Count)
         {
-	        processor.CleanScenario(scenario);
-        }
+            // Export data
+            foreach (var exporter in exporters)
+            {
+                exporter.SetConfiguration(config);
+                if (exporter.Enabled)
+                {
+                    exporter.Export(scenariosResults);
+                }
+            }
 
-	    Environment.Exit(1);
+            // Clean scenarios
+            foreach (var scenario in config.Scenarios)
+            {
+                processor.CleanScenario(scenario);
+            }
+        }
+        else
+        {
+            AnsiConsole.WriteLine();
+
+            for (var i = 0; i < scenariosResults.Count; i++)
+            {
+                if (!string.IsNullOrEmpty(scenariosResults[i].Error))
+                {
+                    AnsiConsole.MarkupLine("[red]Error in Scenario[/]: {0}", scenariosResults[i].Name);
+                    AnsiConsole.WriteLine(scenariosResults[i].Error);
+                }
+            }
+
+            // Clean scenarios
+            foreach (var scenario in config.Scenarios)
+            {
+                processor.CleanScenario(scenario);
+            }
+
+            Environment.Exit(1);
+        }
     }
-}
+}, argument, templateVariables);
+
+
+await root.InvokeAsync(args);

--- a/src/TimeIt/ScenarioProcessor.cs
+++ b/src/TimeIt/ScenarioProcessor.cs
@@ -15,10 +15,12 @@ namespace TimeIt;
 public class ScenarioProcessor
 {
     private readonly Config _configuration;
+    private readonly TemplateVariables _templateVariables;
 
-    public ScenarioProcessor(Config configuration)
+    public ScenarioProcessor(Config configuration, TemplateVariables templateVariables)
     {
         _configuration = configuration;
+        _templateVariables = templateVariables;
     }
 
     public void PrepareScenario(Scenario scenario)
@@ -28,30 +30,30 @@ public class ScenarioProcessor
             scenario.ProcessName = _configuration.ProcessName;
         }
 
-        scenario.ProcessName = Utils.ReplaceCustomVars(scenario.ProcessName ?? string.Empty);
+        scenario.ProcessName = _templateVariables.Expand(scenario.ProcessName ?? string.Empty);
 
         if (string.IsNullOrEmpty(scenario.ProcessArguments))
         {
             scenario.ProcessArguments = _configuration.ProcessArguments;
         }
 
-        scenario.ProcessArguments = Utils.ReplaceCustomVars(scenario.ProcessArguments ?? string.Empty);
+        scenario.ProcessArguments = _templateVariables.Expand(scenario.ProcessArguments ?? string.Empty);
 
         if (string.IsNullOrEmpty(scenario.WorkingDirectory))
         {
             scenario.WorkingDirectory = _configuration.WorkingDirectory;
         }
 
-        scenario.WorkingDirectory = Utils.ReplaceCustomVars(scenario.WorkingDirectory ?? string.Empty);
+        scenario.WorkingDirectory = _templateVariables.Expand(scenario.WorkingDirectory ?? string.Empty);
 
         foreach (var item in scenario.EnvironmentVariables)
         {
-            scenario.EnvironmentVariables[item.Key] = Utils.ReplaceCustomVars(item.Value);
+            scenario.EnvironmentVariables[item.Key] = _templateVariables.Expand(item.Value);
         }
 
         foreach (var item in _configuration.EnvironmentVariables)
         {
-            var value = Utils.ReplaceCustomVars(item.Value);
+            var value = _templateVariables.Expand(item.Value);
             if (!scenario.EnvironmentVariables.ContainsKey(item.Key))
             {
                 scenario.EnvironmentVariables[item.Key] = value;
@@ -60,7 +62,7 @@ public class ScenarioProcessor
 
         foreach (var (tagName, tagValue) in _configuration.Tags)
         {
-            var value = Utils.ReplaceCustomVars(tagValue);
+            var value = _templateVariables.Expand(tagValue);
             if (!scenario.Tags.ContainsKey(tagName))
             {
                 scenario.Tags[tagName] = value;
@@ -69,12 +71,12 @@ public class ScenarioProcessor
 
         for (var i = 0; i < scenario.PathValidations.Count; i++)
         {
-            scenario.PathValidations[i] = Utils.ReplaceCustomVars(scenario.PathValidations[i]);
+            scenario.PathValidations[i] = _templateVariables.Expand(scenario.PathValidations[i]);
         }
 
         foreach (var item in _configuration.PathValidations)
         {
-            var value = Utils.ReplaceCustomVars(item);
+            var value = _templateVariables.Expand(item);
             var idx = scenario.PathValidations.IndexOf(value);
             if (idx == -1)
             {
@@ -122,14 +124,14 @@ public class ScenarioProcessor
             scenario.Timeout.ProcessName = _configuration.Timeout.ProcessName;
         }
 
-        scenario.Timeout.ProcessName = Utils.ReplaceCustomVars(scenario.Timeout.ProcessName ?? string.Empty);
+        scenario.Timeout.ProcessName = _templateVariables.Expand(scenario.Timeout.ProcessName ?? string.Empty);
 
         if (string.IsNullOrEmpty(scenario.Timeout.ProcessArguments))
         {
             scenario.Timeout.ProcessArguments = _configuration.Timeout.ProcessArguments;
         }
 
-        scenario.Timeout.ProcessArguments = Utils.ReplaceCustomVars(scenario.Timeout.ProcessArguments ?? string.Empty);
+        scenario.Timeout.ProcessArguments = _templateVariables.Expand(scenario.Timeout.ProcessArguments ?? string.Empty);
     }
 
     public void CleanScenario(Scenario scenario)
@@ -436,7 +438,7 @@ public class ScenarioProcessor
                             {
                                 inProcStartDate = DateTime.FromBinary((long)metricItem.Value);
                                 metrics[Constants.ProcessTimeToStartMetricName] = (inProcStartDate.Value - dataPoint.Start).TotalMilliseconds;
-                                
+
 
                                 continue;
                             }

--- a/src/TimeIt/TemplateVariables.cs
+++ b/src/TimeIt/TemplateVariables.cs
@@ -1,0 +1,53 @@
+﻿using Spectre.Console;
+using System.Text;
+
+namespace TimeIt;
+
+public class TemplateVariables
+{
+    private static readonly string VariableOpen = "$(";
+    private static readonly string VariableClose = ")";
+
+    private readonly Dictionary<string, string> _variables = new();
+
+    public TemplateVariables()
+    {
+        // default one
+        _variables.Add(CreateVariable("CWD"), Environment.CurrentDirectory);
+    }
+
+    public int Length => _variables.Count;
+
+    public void Add(string name, string value)
+    {
+        var key = CreateVariable(name);
+        if (_variables.ContainsKey(key))
+        {
+            AnsiConsole.MarkupLine("[bold red] This variable '{0}' already exists.[/]", name);
+            return;
+        }
+        _variables.Add(key, value);
+    }
+
+    public string Expand(string s)
+    {
+        if (string.IsNullOrWhiteSpace(s))
+            return s;
+
+        if (!s.Contains(VariableOpen))
+            return s;
+
+        var sb = new StringBuilder(s);
+        foreach( var (k, v) in _variables)
+        {
+            sb.Replace(k, v);
+        }
+
+        return sb.ToString();
+    }
+
+    private static string CreateVariable(string name)
+    {
+        return $"{VariableOpen}{name}{VariableClose}";
+    }
+}

--- a/src/TimeIt/TimeIt.csproj
+++ b/src/TimeIt/TimeIt.csproj
@@ -20,6 +20,7 @@
         <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Spectre.Console" Version="0.47.0" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/TimeIt/Utils.cs
+++ b/src/TimeIt/Utils.cs
@@ -4,11 +4,6 @@ namespace TimeIt;
 
 static class Utils
 {
-    public static string ReplaceCustomVars(string value)
-    {
-        return value.Replace("$(CWD)", Environment.CurrentDirectory);
-    }
-
     public static IEnumerable<double> RemoveOutliers(IEnumerable<double> data, double threshold)
     {
         if (data is not List<double>)


### PR DESCRIPTION
The goal of this PR is to add the support for template variable.

### Context

Currently, for example, if you want to run a benchmark on different architectures, you would create as much config file as architectures you would like to bench.
For example, you could have you application built into different folders based on the architecture (x86 vs x64)

```
  "processName": "dotnet",
  "processArguments": "MyAwesomeApp.dll",
  "processTimeout": 15,
  "workingDirectory": "$(CWD)\\bin\\Release-x64\\MySuperApp",
```

Here the `workingDirectory` points to a `Release-x64` folder and for the 32-bits version, it will be a `Release-x86`.

We could have only one template file like:
```
"processName": "dotnet",
  "processArguments": "MyAwesomeApp.dll",
  "processTimeout": 15,
  "workingDirectory": "$(CWD)\\bin\\Release-$(ARCH)\\MySuperApp",
```

Here we have the `$(ARCH)` variable that would be instantiated to the value passed on the command-line:
 `dotnet timeit myconfig.json --variable ARCH=x64`

This would give us
```
"processName": "dotnet",
  "processArguments": "MyAwesomeApp.dll",
  "processTimeout": 15,
  "workingDirectory": "$(CWD)\\bin\\Release-x64\\MySuperApp",
```

or 
```
"processName": "dotnet",
  "processArguments": "MyAwesomeApp.dll",
  "processTimeout": 15,
  "workingDirectory": "$(CWD)\\bin\\Release-x64\\MySuperApp",
```

if the command-line is `dotnet timeit myconfig.json --variable ARCH=x86`