### PR TITLE
Fix tags/environment variables collection

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.0.9</Version>
+        <Version>0.0.10</Version>
         <Authors>Tony Redondo</Authors>
         <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TimeIt/ScenarioProcessor.cs
+++ b/src/TimeIt/ScenarioProcessor.cs
@@ -58,6 +58,15 @@ public class ScenarioProcessor
             }
         }
 
+        foreach (var (tagName, tagValue) in _configuration.Tags)
+        {
+            var value = Utils.ReplaceCustomVars(tagValue);
+            if (!scenario.Tags.ContainsKey(tagName))
+            {
+                scenario.Tags[tagName] = value;
+            }
+        }
+
         for (var i = 0; i < scenario.PathValidations.Count; i++)
         {
             scenario.PathValidations[i] = Utils.ReplaceCustomVars(scenario.PathValidations[i]);
@@ -131,6 +140,7 @@ public class ScenarioProcessor
     {
         Stopwatch? watch = null;
         AnsiConsole.MarkupLine("[dodgerblue1]Scenario:[/] {0}", scenario.Name);
+
         if (scenario.PathValidations.Count > 0)
         {
             AnsiConsole.MarkupLine("  [gold3_1]Path validations.[/]");

--- a/src/TimeIt/Utils.cs
+++ b/src/TimeIt/Utils.cs
@@ -20,12 +20,12 @@ static class Utils
         var stdDev = data.StandardDeviation();
         return data.Where(x => Math.Abs(x - mean) <= threshold * stdDev).ToList();
     }
-    
+
     public static double FromNanosecondsToMilliseconds(double nanoseconds)
     {
         return TimeSpan.FromTicks((long)nanoseconds / 100).TotalMilliseconds;
     }
-    
+
     public static double FromTimeSpanToNanoseconds(TimeSpan timeSpan)
     {
         return (double)timeSpan.Ticks * 100;


### PR DESCRIPTION
As of today, when collecting tags for each scenario results, we apply the one from the scenario but not the ones from the configuration (global scope).

Which in most cases sets not tags for each result.

This PR tries to fix it by merging the tags  from the configuration and the scenario together. In case of a duplicate, we keep the value from the scenario (what has already been done for environment variables)