### PR TITLE
Limit test span size by limiting number of metrics.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.0.13</Version>
+        <Version>0.0.14</Version>
         <Authors>Tony Redondo</Authors>
         <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TimeIt.DatadogExporter/TimeItDatadogExporter.cs
+++ b/src/TimeIt.DatadogExporter/TimeItDatadogExporter.cs
@@ -85,7 +85,16 @@ public class TimeItDatadogExporter : IExporter
 
                 foreach (var metric in scenarioResult.Metrics)
                 {
-                    test.SetTag($"metrics.{metric.Key}", metric.Value);
+                    // Due to a backend limitation on big objects we only store metrics ending in
+                    // .n, .mean, .max, .min and .std_dev
+                    if (metric.Key.EndsWith(".n") ||
+                        metric.Key.EndsWith(".mean") ||
+                        metric.Key.EndsWith(".max") ||
+                        metric.Key.EndsWith(".min") ||
+                        metric.Key.EndsWith(".std_dev"))
+                    {
+                        test.SetTag($"metrics.{metric.Key}", metric.Value);
+                    }
                 }
 
                 // Set Error

--- a/src/TimeIt.RuntimeMetrics/MetricsName.cs
+++ b/src/TimeIt.RuntimeMetrics/MetricsName.cs
@@ -7,9 +7,7 @@ public static class MetricsNames
     public const string ExceptionsCount = "runtime.dotnet.exceptions.count";
 
     public const string Gen0CollectionsCount = "runtime.dotnet.gc.count.gen0";
-    public const string Gen0CompactingCollectionsCount = "runtime.dotnet.gc.count.compacting_gen0";
     public const string Gen1CollectionsCount = "runtime.dotnet.gc.count.gen1";
-    public const string Gen1CompactingCollectionsCount = "runtime.dotnet.gc.count.compacting_gen1";
     public const string Gen2CollectionsCount = "runtime.dotnet.gc.count.gen2";
     public const string Gen2CompactingCollectionsCount = "runtime.dotnet.gc.count.compacting_gen2";
 

--- a/src/TimeIt/ScenarioProcessor.cs
+++ b/src/TimeIt/ScenarioProcessor.cs
@@ -54,19 +54,13 @@ public class ScenarioProcessor
         foreach (var item in _configuration.EnvironmentVariables)
         {
             var value = _templateVariables.Expand(item.Value);
-            if (!scenario.EnvironmentVariables.ContainsKey(item.Key))
-            {
-                scenario.EnvironmentVariables[item.Key] = value;
-            }
+            scenario.EnvironmentVariables.TryAdd(item.Key, value);
         }
 
         foreach (var (tagName, tagValue) in _configuration.Tags)
         {
             var value = _templateVariables.Expand(tagValue);
-            if (!scenario.Tags.ContainsKey(tagName))
-            {
-                scenario.Tags[tagName] = value;
-            }
+            scenario.Tags.TryAdd(tagName, value);
         }
 
         for (var i = 0; i < scenario.PathValidations.Count; i++)


### PR DESCRIPTION
Due to a Datadog backend limitation on big objects we only store metrics ending in .n, .mean, .max, .min and .std_dev