### PR TITLE
Fix outliers removal when StdDev is 0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.0.15</Version>
+        <Version>0.0.16</Version>
         <Authors>Tony Redondo, Grégory Léocadie</Authors>
         <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TimeIt/Utils.cs
+++ b/src/TimeIt/Utils.cs
@@ -11,8 +11,14 @@ static class Utils
             data = data.ToList();
         }
 
-        var mean = data.Average();
         var stdDev = data.StandardDeviation();
+
+        if (stdDev == 0.0)
+        {
+            return data;
+        }
+
+        var mean = data.Average();
         return data.Where(x => Math.Abs(x - mean) <= threshold * stdDev).ToList();
     }
 


### PR DESCRIPTION
If the standard deviation is 0 (same values), all elements will be removed from the list.
But in reality, it means that there are no outliers, so we should keep them.