### PR TITLE
Check IsNan to avoid removing all data

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.0.16</Version>
+        <Version>0.0.17</Version>
         <Authors>Tony Redondo, Grégory Léocadie</Authors>
         <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TimeIt/Utils.cs
+++ b/src/TimeIt/Utils.cs
@@ -13,7 +13,7 @@ static class Utils
 
         var stdDev = data.StandardDeviation();
 
-        if (stdDev == 0.0)
+        if (stdDev == 0.0 || double.IsNaN(stdDev))
         {
             return data;
         }

--- a/src/TimeIt/Utils.cs
+++ b/src/TimeIt/Utils.cs
@@ -1,9 +1,17 @@
-﻿using MathNet.Numerics.Statistics;
-
-namespace TimeIt;
+﻿namespace TimeIt;
 
 static class Utils
 {
+    public static double StandardDeviation(this IEnumerable<double> data)
+    {
+        var stdDev = MathNet.Numerics.Statistics.Statistics.StandardDeviation(data);
+        if (double.IsNaN(stdDev))
+        {
+            return 0.0;
+        }
+        return stdDev;
+    }
+
     public static IEnumerable<double> RemoveOutliers(IEnumerable<double> data, double threshold)
     {
         if (data is not List<double>)
@@ -13,7 +21,7 @@ static class Utils
 
         var stdDev = data.StandardDeviation();
 
-        if (stdDev == 0.0 || double.IsNaN(stdDev))
+        if (stdDev == 0.0)
         {
             return data;
         }


### PR DESCRIPTION
If there is 1 or no data in the list, `StandardDeviation` returns `double.NaN`. This implies that if there is only one element (so no outlier), the list will be emptied.
We must check for `double.IsNaN` before.