### PR TITLE
Add support for the Datadog's Profiler

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.1.15</Version>
+        <Version>0.1.16</Version>
         <Authors>Tony Redondo, Grégory Léocadie</Authors>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TimeItSharp.Common/DatadogMetadata.cs
+++ b/src/TimeItSharp.Common/DatadogMetadata.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Concurrent;
+using DatadogTestLogger.Vendors.Datadog.Trace;
+using DatadogTestLogger.Vendors.Datadog.Trace.Ci;
+using DatadogTestLogger.Vendors.Datadog.Trace.Util;
+
+namespace TimeItSharp.Common;
+
+internal static class DatadogMetadata
+{
+    private static readonly ConcurrentDictionary<object, Metadata> MetadataByExecution;
+
+    static DatadogMetadata()
+    {
+        MetadataByExecution = new();
+        CIVisibility.InitializeFromManualInstrumentation();
+    }
+
+    public static void GetIds(object key, out TraceId traceId, out ulong spanId)
+    {
+        var value = MetadataByExecution.GetOrAdd(key, @case => new());
+        if (value.TraceId is null)
+        {
+            var useAllBits = CIVisibility.Settings.TracerSettings?.TraceId128BitGenerationEnabled ?? true;
+            value.TraceId = RandomIdGenerator.Shared.NextTraceId(useAllBits);
+            value.SpanId = RandomIdGenerator.Shared.NextSpanId(useAllBits);
+        }
+
+        traceId = value.TraceId.Value;
+        spanId = value.SpanId;
+    }
+
+    private class Metadata
+    {
+        public TraceId? TraceId { get; set; }
+
+        public ulong SpanId { get; set; }
+    }
+}

--- a/src/TimeItSharp.Common/Exporters/DatadogExporter.cs
+++ b/src/TimeItSharp.Common/Exporters/DatadogExporter.cs
@@ -56,7 +56,16 @@ public sealed class DatadogExporter : IExporter
             for (var i = 0; i < results.Scenarios.Count; i++)
             {
                 var scenarioResult = results.Scenarios[i];
-                var test = testSuite.InternalCreateTest(scenarioResult.Name, scenarioResult.Start);
+                Test? test;
+                if (scenarioResult.Scenario is { } scenario)
+                {
+                    DatadogMetadata.GetIds(scenario, out var traceId, out var spanId);
+                    test = testSuite.InternalCreateTest(scenarioResult.Name, scenarioResult.Start, traceId, spanId);
+                }
+                else
+                {
+                    test = testSuite.InternalCreateTest(scenarioResult.Name, scenarioResult.Start);
+                }
 
                 // Set benchmark metadata
                 test.SetBenchmarkMetadata(new BenchmarkHostInfo

--- a/src/TimeItSharp.Common/Results/DataPoint.cs
+++ b/src/TimeItSharp.Common/Results/DataPoint.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 using TimeItSharp.Common.Assertors;
+using TimeItSharp.Common.Configuration;
 
 namespace TimeItSharp.Common.Results;
 
@@ -66,6 +67,9 @@ public sealed class DataPoint
     
     [JsonIgnore]
     public string StandardOutput { get; set; }
+    
+    [JsonIgnore]
+    public Scenario? Scenario { get; internal set; }
 
     public DataPoint()
     {

--- a/src/TimeItSharp.Common/ScenarioProcessor.cs
+++ b/src/TimeItSharp.Common/ScenarioProcessor.cs
@@ -465,7 +465,8 @@ internal sealed class ScenarioProcessor
         // Execute the command
         var dataPoint = new DataPoint
         {
-            ShouldContinue = true
+            ShouldContinue = true,
+            Scenario = scenario,
         };
         
         _callbacksTriggers.ExecutionStart(dataPoint, phase, ref cmd);

--- a/src/TimeItSharp.Common/Services/DatadogProfilerService.cs
+++ b/src/TimeItSharp.Common/Services/DatadogProfilerService.cs
@@ -219,6 +219,16 @@ public sealed class DatadogProfilerService : IService
         yield return Path.Combine(
             Path.GetDirectoryName(typeof(Datadog.Trace.BenchmarkDotNet.DatadogDiagnoser).Assembly.Location) ?? string.Empty,
             "datadog");
+        
+        // try to locate it in the default path using relative path from the benchmark assembly.
+        yield return Path.Combine(
+            Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory) ?? string.Empty,
+            "datadog");
+        
+        // try to locate it in the default path using relative path from the current directory.
+        yield return Path.Combine(
+            Environment.CurrentDirectory,
+            "datadog");
     }
     
     private static bool GetProfilerPaths(string monitoringHome, ref string? profiler32Path, ref string? profiler64Path, ref string? loaderConfig, ref string? ldPreload)

--- a/src/TimeItSharp.Common/Services/DatadogProfilerService.cs
+++ b/src/TimeItSharp.Common/Services/DatadogProfilerService.cs
@@ -4,6 +4,7 @@ using DatadogTestLogger.Vendors.Datadog.Trace.Ci;
 using DatadogTestLogger.Vendors.Datadog.Trace.Ci.Tags;
 using DatadogTestLogger.Vendors.Datadog.Trace.Configuration;
 using DatadogTestLogger.Vendors.Datadog.Trace.Util;
+using Spectre.Console;
 using TimeItSharp.Common.Configuration;
 using TimeItSharp.Common.Results;
 
@@ -11,11 +12,22 @@ namespace TimeItSharp.Common.Services;
 
 public sealed class DatadogProfilerService : IService
 {
+    private bool _isEnabled = false;
+    
     public string Name => nameof(DatadogProfilerService);
 
     public void Initialize(InitOptions options, TimeItCallbacks callbacks)
     {
         callbacks.OnExecutionStart += CallbacksOnOnExecutionStart;
+        callbacks.OnFinish += CallbacksOnOnFinish;
+    }
+
+    private void CallbacksOnOnFinish()
+    {
+        if (_isEnabled)
+        {
+            AnsiConsole.MarkupLine($"[lime]The Datadog profiler was successfully attached to the .NET processes.[/]");
+        }
     }
 
     private void CallbacksOnOnExecutionStart(DataPoint datapoint, TimeItPhase phase, ref Command command)
@@ -29,6 +41,7 @@ public sealed class DatadogProfilerService : IService
             }
 
             command = command.WithEnvironmentVariables(environmentVariables);
+            _isEnabled = true;
         }
     }
 

--- a/src/TimeItSharp.Common/Services/DatadogProfilerService.cs
+++ b/src/TimeItSharp.Common/Services/DatadogProfilerService.cs
@@ -28,6 +28,10 @@ public sealed class DatadogProfilerService : IService
         {
             AnsiConsole.MarkupLine($"[lime]The Datadog profiler was successfully attached to the .NET processes.[/]");
         }
+        else
+        {
+            AnsiConsole.MarkupLine("[red]The Datadog profiler could not be attached to the .NET processes.[/]");
+        }
     }
 
     private void CallbacksOnOnExecutionStart(DataPoint datapoint, TimeItPhase phase, ref Command command)

--- a/src/TimeItSharp.Common/Services/DatadogProfilerService.cs
+++ b/src/TimeItSharp.Common/Services/DatadogProfilerService.cs
@@ -1,0 +1,270 @@
+﻿using CliWrap;
+using DatadogTestLogger.Vendors.Datadog.Trace;
+using DatadogTestLogger.Vendors.Datadog.Trace.Ci;
+using DatadogTestLogger.Vendors.Datadog.Trace.Ci.Tags;
+using DatadogTestLogger.Vendors.Datadog.Trace.Configuration;
+using DatadogTestLogger.Vendors.Datadog.Trace.Util;
+using TimeItSharp.Common.Configuration;
+using TimeItSharp.Common.Results;
+
+namespace TimeItSharp.Common.Services;
+
+public sealed class DatadogProfilerService : IService
+{
+    public string Name => nameof(DatadogProfilerService);
+
+    public void Initialize(InitOptions options, TimeItCallbacks callbacks)
+    {
+        callbacks.OnExecutionStart += CallbacksOnOnExecutionStart;
+    }
+
+    private void CallbacksOnOnExecutionStart(DataPoint datapoint, TimeItPhase phase, ref Command command)
+    {
+        if (datapoint.Scenario is { } scenario &&
+            GetProfilerEnvironmentVariables(scenario) is { } environmentVariables)
+        {
+            foreach (var kvp in command.EnvironmentVariables)
+            {
+                environmentVariables[kvp.Key] = kvp.Value;
+            }
+
+            command = command.WithEnvironmentVariables(environmentVariables);
+        }
+    }
+
+    public object? GetExecutionServiceData() => null;
+
+    public object? GetScenarioServiceData() => null;
+
+    private static Dictionary<string, string?>? GetProfilerEnvironmentVariables(Scenario scenario)
+    {
+        string? monitoringHome = null;
+        string? profiler32Path = null;
+        string? profiler64Path = null;
+        string? loaderConfig = null;
+        string? ldPreload = null;
+        try
+        {
+            foreach (var homePath in GetProfilersHomeFolder())
+            {
+                if (string.IsNullOrEmpty(homePath) || !Directory.Exists(homePath))
+                {
+                    continue;
+                }
+
+                var tmpHomePath = Path.GetFullPath(homePath);
+                if (GetProfilerPaths(tmpHomePath, ref profiler32Path, ref profiler64Path, ref loaderConfig, ref ldPreload))
+                {
+                    monitoringHome = tmpHomePath;
+                    break;
+                }
+            }
+        }
+        catch (PlatformNotSupportedException)
+        {
+            // Store the exception if the platform is not supported and ignore everything.
+            return null;
+        }
+
+        if (string.IsNullOrEmpty(monitoringHome))
+        {
+            return null;
+        }
+
+        DatadogMetadata.GetIds(scenario, out var traceId, out var spanId);
+        var tracer = Tracer.Instance;
+        var environment = new Dictionary<string, string?>();
+        if (!environment.TryGetValue(ConfigurationKeys.ServiceName, out _))
+        {
+            environment[ConfigurationKeys.ServiceName] = tracer.DefaultServiceName;
+        }
+
+        if (!environment.TryGetValue(ConfigurationKeys.Environment, out _) &&
+            tracer.Settings.EnvironmentInternal is { } environmentInternal)
+        {
+            environment[ConfigurationKeys.Environment] = environmentInternal;
+        }
+
+        if (!environment.TryGetValue(ConfigurationKeys.ServiceVersion, out _) &&
+            tracer.Settings.ServiceVersionInternal is { } serviceVersionInternal)
+        {
+            environment[ConfigurationKeys.ServiceVersion] = serviceVersionInternal;
+        }
+
+        const string ProfilerId = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}";
+        environment["COR_ENABLE_PROFILING"] = "1";
+        environment["CORECLR_ENABLE_PROFILING"] = "1";
+        environment["COR_PROFILER"] = ProfilerId;
+        environment["CORECLR_PROFILER"] = ProfilerId;
+        environment["DD_DOTNET_TRACER_HOME"] = monitoringHome;
+
+        if (profiler32Path != null)
+        {
+            environment["COR_PROFILER_PATH_32"] = profiler32Path;
+            environment["CORECLR_PROFILER_PATH_32"] = profiler32Path;
+        }
+
+        environment["COR_PROFILER_PATH_64"] = profiler64Path;
+        environment["CORECLR_PROFILER_PATH_64"] = profiler64Path;
+
+        if (ldPreload != null)
+        {
+            environment["LD_PRELOAD"] = ldPreload;
+        }
+
+        environment["DD_NATIVELOADER_CONFIGFILE"] = loaderConfig;
+
+        // CI Visibility integration environment variables
+        environment[ConfigurationKeys.CIVisibility.Enabled] = "1";
+        environment["DD_INTERNAL_CIVISIBILITY_RUNTIMEID"] = RuntimeId.Get();
+        environment["DD_INTERNAL_CIVISIBILITY_SPANID"] = spanId.ToString();
+
+        // Profiler options
+        const string profilerEnabled = "DD_PROFILING_ENABLED";
+        if (!environment.TryGetValue(profilerEnabled, out _))
+        {
+            environment[profilerEnabled] = "1";
+        }
+
+        const string profilerCPUEnabled = "DD_PROFILING_CPU_ENABLED";
+        if (!environment.TryGetValue(profilerCPUEnabled, out _))
+        {
+            environment[profilerCPUEnabled] = "1";
+        }
+
+        const string profilerWalltimeEnabled = "DD_PROFILING_WALLTIME_ENABLED";
+        if (!environment.TryGetValue(profilerWalltimeEnabled, out _))
+        {
+            environment[profilerWalltimeEnabled] = "1";
+        }
+
+        const string profilerExceptionEnabled = "DD_PROFILING_EXCEPTION_ENABLED";
+        if (!environment.TryGetValue(profilerExceptionEnabled, out _))
+        {
+            environment[profilerExceptionEnabled] = "1";
+        }
+
+        const string profilerAllocationEnabled = "DD_PROFILING_ALLOCATION_ENABLED";
+        if (!environment.TryGetValue(profilerAllocationEnabled, out _))
+        {
+            environment[profilerAllocationEnabled] = "1";
+        }
+
+        const string profilerLockEnabled = "DD_PROFILING_LOCK_ENABLED";
+        if (!environment.TryGetValue(profilerLockEnabled, out _))
+        {
+            environment[profilerLockEnabled] = "1";
+        }
+
+        const string profilerGcEnabled = "DD_PROFILING_GC_ENABLED";
+        if (!environment.TryGetValue(profilerGcEnabled, out _))
+        {
+            environment[profilerGcEnabled] = "1";
+        }
+
+        const string profilerHeapEnabled = "DD_PROFILING_HEAP_ENABLED";
+        if (!environment.TryGetValue(profilerHeapEnabled, out _))
+        {
+            environment[profilerHeapEnabled] = "1";
+        }
+
+        environment["DD_PROFILING_AGENTLESS"] = CIVisibility.Settings.Agentless ? "1" : "0";
+        environment["DD_PROFILING_UPLOAD_PERIOD"] = "90";
+        environment["DD_INTERNAL_PROFILING_SAMPLING_RATE"] = "1";
+        environment["DD_INTERNAL_PROFILING_WALLTIME_THREADS_THRESHOLD"] = "64";
+        environment["DD_INTERNAL_PROFILING_CODEHOTSPOTS_THREADS_THRESHOLD"] = "64";
+        environment["DD_INTERNAL_PROFILING_CPUTIME_THREADS_THRESHOLD"] = "128";
+        environment["DD_INTERNAL_PROFILING_TIMESTAMPS_AS_LABEL_ENABLED "] = "1";
+        environment["DD_PROFILING_FRAMES_NATIVE_ENABLED "] = "1";
+
+        // Tags
+        var tagsList = new List<string>();
+
+        // Git data
+        if (CIEnvironmentValues.Instance is { } ciEnv)
+        {
+            environment["DD_GIT_REPOSITORY_URL"] = ciEnv.Repository;
+            environment["DD_GIT_COMMIT_SHA"] = ciEnv.Commit;
+
+            if (!string.IsNullOrEmpty(ciEnv.Branch))
+            {
+                tagsList.Add($"{CommonTags.GitBranch}:{ciEnv.Branch}");
+            }
+
+            if (!string.IsNullOrEmpty(ciEnv.Tag))
+            {
+                tagsList.Add($"{CommonTags.GitTag}:{ciEnv.Tag}");
+            }
+        }
+
+        var newDdTags = string.Join(", ", tagsList);
+        if (environment.TryGetValue("DD_TAGS", out var ddTags))
+        {
+            environment["DD_TAGS"] = newDdTags + "," + ddTags;
+        }
+        else
+        {
+            environment["DD_TAGS"] = newDdTags;
+        }
+
+        return environment;
+    }
+    
+    private static IEnumerable<string> GetProfilersHomeFolder()
+    {
+        // try to locate it from the environment variable
+        yield return EnvironmentHelpers.GetEnvironmentVariable("DD_DOTNET_TRACER_HOME");
+        
+        // try to locate it in the default path using relative path from the benchmark assembly.
+        yield return Path.Combine(
+            Path.GetDirectoryName(typeof(Datadog.Trace.BenchmarkDotNet.DatadogDiagnoser).Assembly.Location) ?? string.Empty,
+            "datadog");
+    }
+    
+    private static bool GetProfilerPaths(string monitoringHome, ref string? profiler32Path, ref string? profiler64Path, ref string? loaderConfig, ref string? ldPreload)
+    {
+        var osPlatform = FrameworkDescription.Instance.OSPlatform;
+        var processArch = FrameworkDescription.Instance.ProcessArchitecture;
+        if (string.Equals(osPlatform, OSPlatformName.Windows, StringComparison.OrdinalIgnoreCase))
+        {
+            // set required file paths
+            profiler32Path = Path.Combine(monitoringHome, "win-x86", "Datadog.Trace.ClrProfiler.Native.dll");
+            profiler64Path = Path.Combine(monitoringHome, "win-x64", "Datadog.Trace.ClrProfiler.Native.dll");
+            loaderConfig = Path.Combine(monitoringHome, "win-x64", "loader.conf");
+            ldPreload = null;
+        }
+        else if (string.Equals(osPlatform, OSPlatformName.Linux, StringComparison.OrdinalIgnoreCase))
+        {
+            // set required file paths
+            if (string.Equals(processArch, "arm64", StringComparison.OrdinalIgnoreCase))
+            {
+                const string rid = "linux-arm64";
+                profiler32Path = null;
+                profiler64Path = Path.Combine(monitoringHome, rid, "Datadog.Trace.ClrProfiler.Native.so");
+                loaderConfig = Path.Combine(monitoringHome, rid, "loader.conf");
+                ldPreload = Path.Combine(monitoringHome, rid, "Datadog.Linux.ApiWrapper.x64.so");
+            }
+            else
+            {
+                const string rid = "linux-x64";
+                profiler32Path = null;
+                profiler64Path = Path.Combine(monitoringHome, rid, "Datadog.Trace.ClrProfiler.Native.so");
+                loaderConfig = Path.Combine(monitoringHome, rid, "loader.conf");
+                ldPreload = Path.Combine(monitoringHome, rid, "Datadog.Linux.ApiWrapper.x64.so");
+            }
+        }
+        else if (string.Equals(osPlatform, OSPlatformName.MacOS, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new PlatformNotSupportedException("Datadog Profiler is not supported in macOS");
+        }
+
+        if (!File.Exists(profiler64Path) ||
+            (profiler32Path is not null && !File.Exists(profiler64Path)) ||
+            !File.Exists(loaderConfig))
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/TimeItSharp.Common/TimeItSharp.Common.csproj
+++ b/src/TimeItSharp.Common/TimeItSharp.Common.csproj
@@ -7,7 +7,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>icon.png</PackageIcon>
     <DefineConstants>$(DefineConstants);NOCONSTANTS</DefineConstants>
-    <NoWarn>NETSDK1138,0436</NoWarn>
+    <NoWarn>NETSDK1138,0436,IL3000</NoWarn>
     <InternalsAssemblyUseEmptyMethodBodies>false</InternalsAssemblyUseEmptyMethodBodies>
     <PackageOutputPath>..\..\artifacts</PackageOutputPath>
   </PropertyGroup>

--- a/src/TimeItSharp.Common/TimeItSharp.Common.csproj
+++ b/src/TimeItSharp.Common/TimeItSharp.Common.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="CliWrap" Version="3.6.4" />
+    <PackageReference Include="Datadog.Trace.BenchmarkDotNet" Version="2.47.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.48.0" />
     <PackageReference Include="IgnoresAccessChecksToGenerator" Version="0.6.0" />

--- a/src/TimeItSharp/Program.cs
+++ b/src/TimeItSharp/Program.cs
@@ -49,6 +49,7 @@ var templateVariables = new Option<TemplateVariables>(
     }) { Arity = ArgumentArity.OneOrMore };
 var count = new Option<int?>("--count", "Number of iterations to run");
 var warmup = new Option<int?>("--warmup", "Number of iterations to warm up");
+var metrics = new Option<bool>("--metrics", () => true, "Enable Metrics from startup hook");
 var jsonExporter = new Option<bool>("--json-exporter", () => false, "Enable JSON exporter");
 var datadogExporter = new Option<bool>("--datadog-exporter", () => false, "Enable Datadog exporter");
 var datadogProfiler = new Option<bool>("--datadog-profiler", () => false, "Enable Datadog profiler");
@@ -59,12 +60,13 @@ var root = new RootCommand
     templateVariables,
     count,
     warmup,
+    metrics,
     jsonExporter,
     datadogExporter,
     datadogProfiler,
 };
 
-root.SetHandler(async (configFile, templateVariables, countValue, warmupValue, jsonExporterValue, datadogExporterValue, datadogProfilerValue) =>
+root.SetHandler(async (configFile, templateVariables, countValue, warmupValue, metricsValue, jsonExporterValue, datadogExporterValue, datadogProfilerValue) =>
 {
     var isConfigFile = false;
     if (File.Exists(configFile))
@@ -118,7 +120,7 @@ root.SetHandler(async (configFile, templateVariables, countValue, warmupValue, j
             .WithName(configFile)
             .WithProcessName(processName)
             .WithProcessArguments(processArgs)
-            .WithMetrics(true)
+            .WithMetrics(metricsValue)
             .WithWarmupCount(warmupValue ?? 1)
             .WithCount(countValue ?? 10)
             .WithExporter<ConsoleExporter>()
@@ -147,6 +149,6 @@ root.SetHandler(async (configFile, templateVariables, countValue, warmupValue, j
     {
         Environment.Exit(exitCode);
     }
-}, argument, templateVariables, count, warmup, jsonExporter, datadogExporter, datadogProfiler);
+}, argument, templateVariables, count, warmup, metrics, jsonExporter, datadogExporter, datadogProfiler);
 
 await root.InvokeAsync(args);

--- a/src/TimeItSharp/Program.cs
+++ b/src/TimeItSharp/Program.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using TimeItSharp.Common.Configuration;
 using TimeItSharp.Common.Configuration.Builder;
 using TimeItSharp.Common.Exporters;
+using TimeItSharp.Common.Services;
 
 var version = typeof(Program).Assembly.GetName().Version!;
 AnsiConsole.MarkupLine("[bold dodgerblue1 underline]TimeItSharp v{0}[/]", $"{version.Major}.{version.Minor}.{version.Build}");
@@ -50,6 +51,7 @@ var count = new Option<int?>("--count", "Number of iterations to run");
 var warmup = new Option<int?>("--warmup", "Number of iterations to warm up");
 var jsonExporter = new Option<bool>("--json-exporter", () => false, "Enable JSON exporter");
 var datadogExporter = new Option<bool>("--datadog-exporter", () => false, "Enable Datadog exporter");
+var datadogProfiler = new Option<bool>("--datadog-profiler", () => false, "Enable Datadog profiler");
 
 var root = new RootCommand
 {
@@ -58,10 +60,11 @@ var root = new RootCommand
     count,
     warmup,
     jsonExporter,
-    datadogExporter
+    datadogExporter,
+    datadogProfiler,
 };
 
-root.SetHandler(async (configFile, templateVariables, countValue, warmupValue, jsonExporterValue, datadogExporterValue) =>
+root.SetHandler(async (configFile, templateVariables, countValue, warmupValue, jsonExporterValue, datadogExporterValue, datadogProfilerValue) =>
 {
     var isConfigFile = false;
     if (File.Exists(configFile))
@@ -132,6 +135,11 @@ root.SetHandler(async (configFile, templateVariables, countValue, warmupValue, j
             configBuilder.WithExporter<DatadogExporter>();
         }
 
+        if (datadogProfilerValue)
+        {
+            configBuilder.WithService<DatadogProfilerService>();
+        }
+
         exitCode = await TimeItEngine.RunAsync(configBuilder, new TimeItOptions(templateVariables)).ConfigureAwait(false);
     }
     
@@ -139,6 +147,6 @@ root.SetHandler(async (configFile, templateVariables, countValue, warmupValue, j
     {
         Environment.Exit(exitCode);
     }
-}, argument, templateVariables, count, warmup, jsonExporter, datadogExporter);
+}, argument, templateVariables, count, warmup, jsonExporter, datadogExporter, datadogProfiler);
 
 await root.InvokeAsync(args);

--- a/src/TimeItSharp/config-example.json
+++ b/src/TimeItSharp/config-example.json
@@ -11,6 +11,9 @@
   "services": [
     {
       "name": "NoopService"
+    },
+    {
+      "name": "DatadogProfilerService"
     }
   ],
   "scenarios": [

--- a/test/TimeItSharp.FluentConfiguration.Sample/Program.cs
+++ b/test/TimeItSharp.FluentConfiguration.Sample/Program.cs
@@ -13,7 +13,7 @@ var config = ConfigBuilder.Create()
     .WithMetricsProcessName("dotnet")
     .WithExporters<ConsoleExporter, JsonExporter, DatadogExporter>()
     .WithAssertor<DefaultAssertor>()
-    .WithService<NoopService>()
+    .WithService<DatadogProfilerService>()
     .WithProcessName("dotnet")
     .WithProcessArguments("--version")
     .WithEnvironmentVariables(new Dictionary<string, string>


### PR DESCRIPTION
This PR adds support for enabling the Datadog Profiler over the time-it target for .NET process

### Example:

Command:
```script
dotnet run --framework net8.0 -- "dotnet --info" --datadog-profiler --datadog-exporter --metrics=false
```

Output:
```log
TimeItSharp v0.1.16
Configuration file not found, trying to run as a process name...
Warmup count: 1
Count: 10
Number of Scenarios: 1
Exporters: ConsoleExporter, Datadog
Assertors: DefaultAssertor
Services: DatadogProfilerService

Scenario: Default
  Warming up .
    Duration: 2,262s
  Run ..........
    Duration: 18,087s

### Results:

|   Default   |
| :---------: |
| 1807,3131ms |
| 1714,5623ms |
| 1793,3995ms |
| 1884,2743ms |
| 1808,3593ms |
| 1822,7969ms |
| 1746,7585ms |
| 1729,6576ms |
| 1805,7147ms |
|      -      |

### Outliers:

|   Default   |
| :---------: |
| 1930,0928ms |

### Distribution:

Default:
 1714,5623ms - 1746,7585ms: ██████ (3)
 1793,3995ms - 1822,7969ms: ██████████ (5)
 1884,2743ms - 1884,2743ms: ██ (1)

### Summary:
                                                                                                                                           
| Name    | Status | Mean        | StdDev    | StdErr    | Min         | Median      | Max         | P95         | P90         | Outliers |
| ------- | ------ | ----------- | --------- | --------- | ----------- | ----------- | ----------- | ----------- | ----------- | -------- |
| Default | Passed | 1790,3151ms | 52,5114ms | 17,5038ms | 1714,5623ms | 1805,7147ms | 1884,2743ms | 1884,2743ms | 1867,8803ms | 1 {1,4}  |


The Datadog exported ran successfully.
The Datadog profiler was successfully attached to the .NET processes.

```

### Screenshots:
![image](https://github.com/tonyredondo/timeitsharp/assets/69803/7be04903-ae25-4e36-937a-0b797772e648)

![image](https://github.com/tonyredondo/timeitsharp/assets/69803/554a6231-073e-4046-a7c5-3f31eb3a59e5)

![image](https://github.com/tonyredondo/timeitsharp/assets/69803/8711d5d3-cae7-465f-b272-7fee5f9460df)

![image](https://github.com/tonyredondo/timeitsharp/assets/69803/e16bf72a-fda2-4f07-8146-660883138b8b)
