### PR TITLE
Fix unhandled exception and bump to v0.4.5

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>0.4.4</Version>
+        <Version>0.4.5</Version>
         <Authors>Tony Redondo, Grégory Léocadie</Authors>
         <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/TimeItSharp.Common/Exporters/ConsoleExporter.cs
+++ b/src/TimeItSharp.Common/Exporters/ConsoleExporter.cs
@@ -197,7 +197,7 @@ public sealed class ConsoleExporter : IExporter
                     }
 
 
-                    var mMean =  itemResult.Mean();
+                    var mMean = itemResult.Mean();
                     var mMedian = itemResult.Median();
                     var mStdDev = itemResult.StandardDeviation();
                     var mStdErr = mStdDev / Math.Sqrt(itemResult.Count);

--- a/src/TimeItSharp.Common/Exporters/ConsoleExporter.cs
+++ b/src/TimeItSharp.Common/Exporters/ConsoleExporter.cs
@@ -171,6 +171,7 @@ public sealed class ConsoleExporter : IExporter
                 for (var i = 0; i < totalNum; i++)
                 {
                     var item = orderedMetricsData[i];
+                    var previousResult = item.Value;
                     var itemResult = new List<double>();
                     var metricsOutliers = new List<double>();
                     var metricsThreshold = 0.5d;
@@ -182,19 +183,26 @@ public sealed class ConsoleExporter : IExporter
                         if (outliersPercent < 20)
                         {
                             // outliers must be not more than 20% of the data
+                            // but also we need to ensure that we have some data left, if not we use previous result
+                            if (itemResult.Count == 0)
+                            {
+                                itemResult = previousResult;
+                                metricsOutliers = item.Value.Where(d => !itemResult.Contains(d)).ToList();
+                            }
                             break;
                         }
 
                         metricsThreshold += 0.1;
+                        previousResult = itemResult;
                     }
 
 
-                    var mMean = itemResult.Mean();
+                    var mMean =  itemResult.Mean();
                     var mMedian = itemResult.Median();
                     var mStdDev = itemResult.StandardDeviation();
                     var mStdErr = mStdDev / Math.Sqrt(itemResult.Count);
-                    var mMin = itemResult.Min();
-                    var mMax = itemResult.Max();
+                    var mMin = itemResult.Any() ? itemResult.Min() : 0;
+                    var mMax = itemResult.Any() ? itemResult.Max() : 0;
                     var ci95 = Utils.CalculateConfidenceInterval(mMean, mStdErr, itemResult.Count, 0.95);
 
                     string name;


### PR DESCRIPTION
Fixes an Unhandled exception and ensure to write the exception and setting the ExitCode=1 for these cases.

```
Unhandled exception: System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.MinFloat[T](IEnumerable`1 source)
   at TimeItSharp.Common.Exporters.ConsoleExporter.Export(TimeitResult results) in /_/src/TimeItSharp.Common/Exporters/ConsoleExporter.cs:line 196
   at TimeItSharp.Common.TimeItEngine.RunAsync(Config config, TimeItOptions options, Nullable`1 cancellation***) in /_/src/TimeItSharp.Common/TimeItEngine.cs:line 167
   at Program.<>c__DisplayClass0_0.<<<Main>$>b__7>d.MoveNext() in /_/src/TimeItSharp/Program.cs:line 127
--- End of stack trace from previous location ---
   at System.CommandLine.Invocation.AnonymousCommandHandler.InvokeAsync(InvocationContext context)
   at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass17_0.<<UseParseErrorReporting>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass12_0.<<UseHelp>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass22_0.<<UseVersionOption>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass19_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__18_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass16_0.<<UseParseDirective>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<RegisterWithDotnetSuggest>b__5_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass8_0.<<UseExceptionHandler>b__0>d.MoveNext()
```